### PR TITLE
Fix of the compare function

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ module.exports = function (target, entries, opts) {
 		else
 		{
 			if (a.dist < b.dist) return 1
-			else return -1
+                        else if (a.dist > b.dist) return -1
+			else return 0
 		}
 	}).map(function(entry) {
 		return entry.value


### PR DESCRIPTION
The previous version of the compare function was not consistent (it did not follow the requirements on the compare function), see https://tc39.github.io/ecma262/#sec-array.prototype.sort for details. The tests of this package are too small to notice that on V8 (the default JavaScript engine of Node.js) but 2 of the tests fail on an alternative JavaScript engine that I tried.